### PR TITLE
Add package.json to make it possible install from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "source-code-editor-tinymce-plugin",
+  "version": "1.0.0",
+  "description": "Advanced Source Code Editor plugin for Tinymce WYSIWYG Editor built alongside ACE",
+  "main": " ",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/melquibrito/source-code-editor-tinymce-plugin.git"
+  },
+  "keywords": [
+    "tinymce",
+    "ace",
+    "ace-editor",
+    "wysiwyg-editor",
+    "wysiwyg",
+    "source-code-extension",
+	"tinymce-plugin",
+    "codeeditor",
+    "ace-theme"
+  ],
+  "author": "melquibrito",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/melquibrito/source-code-editor-tinymce-plugin/issues"
+  },
+  "homepage": "https://github.com/melquibrito/source-code-editor-tinymce-plugin#readme"
+}


### PR DESCRIPTION
I just added a simple package.json that will make it possible to install via npm:

`npm i https://github.com/melquibrito/source-code-editor-tinymce-plugin`

and be useful for everyone to use. Thanks for this plugin

